### PR TITLE
Updated Eureka Service spring-cloud-dependencies version

### DIFF
--- a/eureka-service/pom.xml
+++ b/eureka-service/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Finchley.BUILD-SNAPSHOT</spring-cloud.version>
+        <spring-cloud.version>Finchley.RELEASE</spring-cloud.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The BUILD-SNAPSHOT version of spring-cloud-dependencies has been removed from the maven repository. Updated to RELEASE.